### PR TITLE
Fixed settings VC dismissal when the screen is pushed instead of presented as modal

### DIFF
--- a/Neon/Custom Controllers/NeonSettingsController/NeonSettingsController.swift
+++ b/Neon/Custom Controllers/NeonSettingsController/NeonSettingsController.swift
@@ -70,6 +70,7 @@ open class NeonSettingsController: UIViewController {
     
     @objc private func backButtonTapped() {
         dismiss(animated: true, completion: nil)
+        navigationController?.popViewController(animated: true)
     }
 
     public func configure(


### PR DESCRIPTION
**Changes:**
Added an extra line on the setting's back button to dismiss the screen in case it has been pushed from the navigation controller instead of presented as a modal.